### PR TITLE
fixes to prevent request() floodings.

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -19,8 +19,12 @@
             "de": "Tankerkönig Spritpreise",
             "ru": "Tankerkoenig Цены на топливо"
         },
-        "version": "2.0.4",
+        "version": "2.0.5",
         "news": {
+            "2.0.5": {
+              "en": "Fixes against request() flooding",
+              "de": "Bugfixes um multiple request() auszuschliessen"
+            },
             "2.0.4": {
               "en": "Final fix for sync issues and further translations",
               "de": "Behebung der Synchronisierungsprobleme und weitere Übersetzungen",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.tankerkoenig",
   "description": "Spritpreise von tankerkoenig.de",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "pix",
   "contributors": [
     "pix"


### PR DESCRIPTION
This PR fixes request() flooding due to `sync_milliseconds` being NaN in a fresh installation of v2 of ioBroker.tankerkoenig. In Addition, it sets a proper User-Agent to the request header so that Tankerkönig could better react in future to such adapter issues.

This fixes #29.